### PR TITLE
fix: comma-separate hub messages number

### DIFF
--- a/src/components/hubs-data.tsx
+++ b/src/components/hubs-data.tsx
@@ -29,7 +29,7 @@ const HubsDataComponent = () => {
             <div>
               {hub.dbStats.numMessages !== null ? (
                 <p className="text-center font-bold">
-                  {hub?.dbStats?.numMessages}
+                  {hub?.dbStats?.numMessages.toLocaleString()}
                 </p>
               ) : (
                 <p className="text-center">Loading...</p>


### PR DESCRIPTION
comma-separates the "Number of Messages on [hub]" stat with `toLocaleString()` (example screenshot below)

<img width="647" alt="Screenshot 2024-06-27 at 2 07 51 PM" src="https://github.com/neynarxyz/explorer/assets/12853808/8ba67df6-e44c-495f-94c9-4ee195471636">